### PR TITLE
Fix adjacency rules on browser side

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         </button>
     </header>
 
-    <p class="text-center mb-6 text-[var(--text-subtle)]">Place a queen in each row, column, and colored region.</p>
+    <p class="text-center mb-6 text-[var(--text-subtle)]">Place a queen in each row, column, and colored region without any two queens touching.</p>
 
     <div id="loading-overlay" class="absolute inset-0 flex-col justify-center items-center z-10 rounded-xl hidden">
         <div class="w-12 h-12 rounded-full animate-spin border-4 border-solid border-gray-300 border-t-blue-500"></div>

--- a/main.js
+++ b/main.js
@@ -172,13 +172,13 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (rows.size !== state.gridSize || cols.size !== state.gridSize || regs.size !== state.gridSize) return false;
 
-        // Check that no two queens are adjacent (sharing a side)
+        // Check that no two queens are adjacent (including diagonals)
         for (let i = 0; i < queens.length; i++) {
             for (let j = i + 1; j < queens.length; j++) {
                 const [r1, c1] = queens[i], [r2, c2] = queens[j];
                 const rowDist = Math.abs(r1 - r2);
                 const colDist = Math.abs(c1 - c2);
-                if ((rowDist === 1 && colDist === 0) || (rowDist === 0 && colDist === 1)) {
+                if (rowDist <= 1 && colDist <= 1) {
                     return false; // Found adjacent queens
                 }
             }


### PR DESCRIPTION
## Summary
- ensure the browser validator rejects diagonally adjacent queens
- clarify game instructions about no touching queens

## Testing
- `node puzzle_client.js 4 false`

------
https://chatgpt.com/codex/tasks/task_b_686327c3bf308321bd7b293fb190df99