### PR TITLE
Support fast puzzle generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The repository is briefly described as "A special variant of N-Queen Puzzle." Fo
 ### Puzzle Generation (`puzzle_creator.js`)
 - Region generation using `generateColorRegions(m)`.
 - Solution search and validation (`isSafe()` and `solve()`).
-- `generateUniquePuzzle(m)` ensures a single solution and limits retries to 10,000 attempts.
+ - `generateUniquePuzzle(m, requireUnique = true)` generates a puzzle. When `requireUnique` is `false` it skips uniqueness checks for faster generation.
 - `visualizePuzzle()` produces a text grid view of a puzzle.
 
 ### Browser UI (`main.js`)
@@ -39,6 +39,7 @@ The repository is briefly described as "A special variant of N-Queen Puzzle." Fo
 
 ### CLI Usage
 - `puzzle_client.js` exposes `generateUniquePuzzle()` from Node.
+- Call `node puzzle_client.js [grid_size] [save] [fast]` where the optional `fast` flag skips the uniqueness check.
 - Can save puzzles as JSON and text via command-line flags.
 
 ### Python Prototype

--- a/main.js
+++ b/main.js
@@ -22,6 +22,10 @@ document.addEventListener('DOMContentLoaded', () => {
         userBoard: [],
     };
 
+    // Check for "fast" query parameter to skip uniqueness checks
+    const urlParams = new URLSearchParams(window.location.search);
+    const fastGeneration = urlParams.get('fast') === '1' || urlParams.get('fast') === 'true';
+
     // --- Theming ---
     function setTheme(mode) {
         if (mode === 'dark') {
@@ -200,7 +204,8 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => {
             try {
                 // This function comes from puzzle_creator.js
-                const puzzle = generateUniquePuzzle(state.gridSize);
+                const requireUnique = !(fastGeneration || state.gridSize > 10);
+                const puzzle = generateUniquePuzzle(state.gridSize, requireUnique);
                 state.regions = puzzle.regions;
                 state.givenQueens = puzzle.given_queens;
                 createGrid();

--- a/puzzle_client.js
+++ b/puzzle_client.js
@@ -1,18 +1,20 @@
 // queen_cli.js
-// Usage: node queen_cli.js [grid_size] [save]
+// Usage: node queen_cli.js [grid_size] [save] [fast]
 
 const fs = require('fs');
 const { generateUniquePuzzle, visualizePuzzle } = require('./puzzle_creator');
 
 const m = parseInt(process.argv[2]) || 8;
 const shouldSave = process.argv[3] === 'true';
+const fastMode = process.argv[4] === 'fast';
 
 const outputFile = 'queen_puzzle.json';
 const resultFile = 'queen_puzzle_result.txt';
 const startTime = Date.now();
 
 try {
-    const puzzle = generateUniquePuzzle(m);
+    const requireUnique = !(fastMode || m > 10);
+    const puzzle = generateUniquePuzzle(m, requireUnique);
     const elapsed = (Date.now() - startTime) / 1000;
 
     const viz = `Time taken: ${elapsed.toFixed(2)} seconds\n\n` + visualizePuzzle(puzzle);


### PR DESCRIPTION
## Summary
- allow skipping uniqueness checks in `generateUniquePuzzle`
- pass the fast option from the browser and CLI
- document the new parameter and CLI usage

## Testing
- `node puzzle_client.js 5 false fast | head -n 20`
- `node puzzle_client.js 11 false fast | head -n 5`
- `node puzzle_client.js 8 false | head -n 5`


------
https://chatgpt.com/codex/tasks/task_b_6863b618078c8321865d4ed0af8c4c4e