### PR TITLE
Allow board sizes up to 20

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,27 @@
     <section class="mb-6 p-4 rounded-lg bg-[var(--surface-low)]">
         <div class="flex flex-wrap justify-center items-center gap-4">
             <label for="size" class="font-medium">Grid Size:</label>
-            <input id="size" type="range" min="4" max="12" value="8" class="w-36 cursor-pointer"/>
+            <select id="size" class="border rounded px-2 py-1 bg-[var(--surface)]">
+                <!-- Options from 4 to 20 -->
+                <!-- Default selected value is 8 -->
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8" selected>8</option>
+                <option value="9">9</option>
+                <option value="10">10</option>
+                <option value="11">11</option>
+                <option value="12">12</option>
+                <option value="13">13</option>
+                <option value="14">14</option>
+                <option value="15">15</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+            </select>
             <span id="size-val" class="font-semibold text-lg text-blue-600 w-8 text-center tabular-nums">8</span>
             <button id="generate" class="btn bg-blue-500 hover:bg-blue-600 text-white px-5 py-2 rounded-lg shadow-md font-semibold">New Puzzle</button>
             <button id="reset" class="btn bg-gray-700 hover:bg-gray-800 text-white px-5 py-2 rounded-lg shadow-md font-semibold">Reset</button>

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const DOM = {
         root: document.documentElement,
         themeToggle: document.getElementById('theme-toggle'),
-        sizeSlider: document.getElementById('size'),
+        sizeSelect: document.getElementById('size'),
         sizeLabel: document.getElementById('size-val'),
         generateBtn: document.getElementById('generate'),
         resetBtn: document.getElementById('reset'),
@@ -55,8 +55,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Color Palette ---
     function getRegionColor(id) {
-        const lightPalette = ["#f87171","#fb923c","#facc15","#a3e635","#60a5fa","#a78bfa","#f472b6","#22d3ee","#4ade80","#38bdf8","#c084fc","#fbbf24"];
-        const darkPalette = ["#ef4444","#f97316","#eab308","#84cc16","#3b82f6","#8b5cf6","#ec4899","#06b6d4","#22c55e","#0ea5e9","#a855f7","#f59e0b"];
+        const lightPalette = [
+            "#f87171","#fb923c","#facc15","#a3e635","#60a5fa","#a78bfa","#f472b6","#22d3ee",
+            "#4ade80","#38bdf8","#c084fc","#fbbf24","#fdba74","#bef264","#fde047","#f9a8d4",
+            "#67e8f9","#6ee7b7","#93c5fd","#ddd6fe"
+        ];
+        const darkPalette = [
+            "#ef4444","#f97316","#eab308","#84cc16","#3b82f6","#8b5cf6","#ec4899","#06b6d4",
+            "#22c55e","#0ea5e9","#a855f7","#f59e0b","#ea580c","#65a30d","#d97706","#db2777",
+            "#0891b2","#16a34a","#2563eb","#7c3aed"
+        ];
         const palette = DOM.root.classList.contains("dark") ? darkPalette : lightPalette;
         return palette[id % palette.length];
     }
@@ -67,7 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
         DOM.loadingOverlay.classList.toggle('flex', isLoading);
         DOM.generateBtn.disabled = isLoading;
         DOM.resetBtn.disabled = isLoading;
-        DOM.sizeSlider.disabled = isLoading;
+        DOM.sizeSelect.disabled = isLoading;
     }
 
     function updateCheckButtonVisibility() {
@@ -224,7 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
         setTheme(isDark ? 'light' : 'dark');
     });
 
-    DOM.sizeSlider.addEventListener('input', (e) => {
+    DOM.sizeSelect.addEventListener('change', (e) => {
         state.gridSize = +e.target.value;
         DOM.sizeLabel.textContent = state.gridSize;
     });


### PR DESCRIPTION
## Summary
- switch grid size control from slider to dropdown so we can offer more board sizes
- support boards up to 20x20
- expand the region color palette
- update JS to work with dropdown

## Testing
- `node puzzle_client.js 8 > /tmp/out.txt && head -n 5 /tmp/out.txt`
- `time node puzzle_client.js 12 fast >/tmp/out12.txt && tail -n 2 /tmp/out12.txt` *(shows generation speed without uniqueness check)*


------
https://chatgpt.com/codex/tasks/task_b_6863bb29fc5c8321ac296963479465ad