### PR TITLE
Limit puzzle size to 13 and adjust colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <div class="flex flex-wrap justify-center items-center gap-4">
             <label for="size" class="font-medium">Grid Size:</label>
             <select id="size" class="border rounded px-2 py-1 bg-[var(--surface)]">
-                <!-- Options from 4 to 20 -->
+                <!-- Options from 4 to 13 -->
                 <!-- Default selected value is 8 -->
                 <option value="4">4</option>
                 <option value="5">5</option>
@@ -47,13 +47,6 @@
                 <option value="11">11</option>
                 <option value="12">12</option>
                 <option value="13">13</option>
-                <option value="14">14</option>
-                <option value="15">15</option>
-                <option value="16">16</option>
-                <option value="17">17</option>
-                <option value="18">18</option>
-                <option value="19">19</option>
-                <option value="20">20</option>
             </select>
             <button id="generate" class="btn bg-blue-500 hover:bg-blue-600 text-white px-5 py-2 rounded-lg shadow-md font-semibold">New Puzzle</button>
             <button id="reset" class="btn bg-gray-700 hover:bg-gray-800 text-white px-5 py-2 rounded-lg shadow-md font-semibold">Reset</button>

--- a/main.js
+++ b/main.js
@@ -55,14 +55,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Color Palette ---
     function getRegionColor(id) {
         const lightPalette = [
-            "#f87171","#fb923c","#facc15","#a3e635","#60a5fa","#a78bfa","#f472b6","#22d3ee",
-            "#4ade80","#38bdf8","#c084fc","#fbbf24","#fdba74","#bef264","#fde047","#f9a8d4",
-            "#67e8f9","#6ee7b7","#93c5fd","#ddd6fe"
+            "#f87171", "#fb923c", "#fbbf24", "#facc15", "#a3e635", "#4ade80", "#22d3ee",
+            "#60a5fa", "#a78bfa", "#c084fc", "#f472b6", "#d946ef", "#06b6d4"
         ];
         const darkPalette = [
-            "#ef4444","#f97316","#eab308","#84cc16","#3b82f6","#8b5cf6","#ec4899","#06b6d4",
-            "#22c55e","#0ea5e9","#a855f7","#f59e0b","#ea580c","#65a30d","#d97706","#db2777",
-            "#0891b2","#16a34a","#2563eb","#7c3aed"
+            "#ef4444", "#f97316", "#d97706", "#eab308", "#84cc16", "#22c55e", "#06b6d4",
+            "#3b82f6", "#8b5cf6", "#a855f7", "#ec4899", "#db2777", "#0e7490"
         ];
         const palette = DOM.root.classList.contains("dark") ? darkPalette : lightPalette;
         return palette[id % palette.length];

--- a/puzzle_client.js
+++ b/puzzle_client.js
@@ -4,7 +4,8 @@
 const fs = require('fs');
 const { generateUniquePuzzle, visualizePuzzle } = require('./puzzle_creator');
 
-const m = parseInt(process.argv[2]) || 8;
+const inputSize = parseInt(process.argv[2]);
+const m = isNaN(inputSize) ? 8 : Math.min(inputSize, 13);
 const shouldSave = process.argv[3] === 'true';
 const fastMode = process.argv[4] === 'fast';
 


### PR DESCRIPTION
## Summary
- cap maximum grid options at 13 in the UI
- shrink the color palettes for clearer region colors
- enforce size cap in the CLI tool

## Testing
- `node puzzle_client.js 15 | head -n 1`
- `node puzzle_client.js 13 > /tmp/out2.txt && tail -n 1 /tmp/out2.txt`

------
https://chatgpt.com/codex/tasks/task_b_6863d0d766c88321962e2c3f36c8739f