### PR TITLE
Fallback to non-unique puzzle after 10k attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The repository is briefly described as "A special variant of N-Queen Puzzle." Fo
 
 ## Notes for New Contributors
 
-1. Puzzle generation is computationally intensive for large boards, so be mindful of the 10,000 attempt limit.
+1. Puzzle generation is computationally intensive for large boards. After 10,000 failed attempts at finding a unique puzzle, the generator automatically falls back to a valid puzzle without uniqueness guarantees.
 2. The browser code relies solely on vanilla JavaScript and Tailwind CSS.
 3. Theme colors are controlled in `style.css` and `getRegionColor()` inside `main.js`.
 4. The core puzzle logic resides in `isSafe()` and `isValidSolution()`; start there when modifying the puzzle rules.

--- a/main.js
+++ b/main.js
@@ -110,10 +110,30 @@ document.addEventListener('DOMContentLoaded', () => {
         DOM.checkBtn.classList.add('hidden');
     }
 
-     function updateTileSize() {
+    function updateTileSize() {
         const containerWidth = DOM.gridContainer.parentElement.clientWidth;
         const tile = Math.min(48, Math.floor((containerWidth - 16) / state.gridSize));
         DOM.root.style.setProperty('--tile-size', `${tile}px`);
+    }
+
+    // Draw a fine border around each color region
+    function applyRegionBorders(tile, r, c) {
+        const id = state.regions[r][c];
+        const lastRow = state.gridSize - 1;
+        const lastCol = state.gridSize - 1;
+
+        tile.style.borderLeft = (c === 0 || state.regions[r][c - 1] !== id)
+            ? '1px solid black'
+            : '1px solid #e2e8f040';
+        tile.style.borderTop = (r === 0 || state.regions[r - 1][c] !== id)
+            ? '1px solid black'
+            : '1px solid #e2e8f040';
+        tile.style.borderRight = (c === lastCol)
+            ? '1px solid black'
+            : '1px solid #e2e8f040';
+        tile.style.borderBottom = (r === lastRow)
+            ? '1px solid black'
+            : '1px solid #e2e8f040';
     }
 
     function createGrid() {
@@ -136,6 +156,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     tile.classList.add('queen', 'given-queen');
                 }
 
+                applyRegionBorders(tile, r, c);
                 tile.addEventListener('click', () => handleTileClick(tile, r, c));
                 DOM.gridContainer.appendChild(tile);
             }

--- a/puzzle_creator.js
+++ b/puzzle_creator.js
@@ -190,6 +190,10 @@ function generateUniquePuzzle(m, requireUnique = true) {
         }
 
         if (attempts > 10000) {
+            if (requireUnique) {
+                console.warn("Unique puzzle not found after 10000 attempts; continuing without uniqueness.");
+                return generateUniquePuzzle(m, false);
+            }
             throw new Error("Failed to generate puzzle after 10000 attempts");
         }
     }


### PR DESCRIPTION
## Summary
- update generation so that if the 10k attempt limit is hit when enforcing uniqueness, generation restarts without the uniqueness check
- document the fallback behaviour in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6865f757456c8321b5dd6e050b614ab6